### PR TITLE
LS-72: Centralize clean, checkstyle, and mocha tasks

### DIFF
--- a/lib/checkstyle.js
+++ b/lib/checkstyle.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var gulp = require('gulp'),
+    jscs = require('gulp-jscs'),
+    lsConfigs = require('ls-default-configs');
+
+module.exports = function lvsfGulpLint(dirsToCheck) {
+    return function checkstyle() {
+        return gulp.src(dirsToCheck).pipe(jscs(lsConfigs.jscsrc));
+    };
+};

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var gulp = require('gulp'),
+    qFs = require('q-io/fs');
+
+module.exports = function lvsfGulpLint(dirToClean, opts) {
+    return function clean() {
+        return qFs.isDirectory(dirToClean).then(function(isDir) {
+            return isDir ? qFs.removeTree(dirToClean) : void 0;
+        });
+    };
+};

--- a/lib/lvsf-gulp-tasks.js
+++ b/lib/lvsf-gulp-tasks.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
-    lint: require('./lint')
+    checkstyle: require('./checkstyle'),
+    clean: require('./clean'),
+    lint: require('./lint'),
+    mocha: require('./mocha')
 };

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var _ = require('ls-lodash'),
+    gulp = require('gulp'),
+    gulpMocha = require('gulp-mocha'),
+    path = require('path');
+
+module.exports = function lvsfGulpMocha(testDirs, opts) {
+    return function mocha() {
+        var useSpecReporter = process.env.CI || process.env.LVSF_NO_SILLY,
+            circleTestReports = process.env.CIRCLE_TEST_REPORTS,
+            mochaOpts = {
+                reporter: useSpecReporter ? 'spec' : 'nyan'
+            };
+            
+        if (circleTestReports) {
+            mochaOpts.reporterOptions = {
+                output: path.join(circleTestReports, 'Mocha', 'tests.xml')
+            }
+        }
+        
+        // Yes, side-effect unsafe merge.  Okay....
+        _.merge(mochaOpts, opts || {});
+
+        return gulp.src(testDirs, { read: false })
+            .pipe(gulpMocha(mochaOpts));
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lvsf-gulp-tasks",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Some common tasks for gulp",
   "main": "lib/lvsf-gulp-tasks.js",
   "scripts": {
@@ -18,11 +18,14 @@
   "homepage": "https://github.com/livesafe/lvsf-gulp-tasks",
   "dependencies": {
     "gulp": "^3.8.11",
+    "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.2",
+    "gulp-mocha": "^2.0.0",
     "jscs": "^1.11.3",
     "jshint": "^2.6.0",
     "jshint-stylish": "^1.0.0",
     "ls-default-configs": "^2.3.0",
-    "merge-stream": "^0.1.7"
+    "merge-stream": "^0.1.7",
+    "q-io": "^1.11.6"
   }
 }


### PR DESCRIPTION
### Testing
1. Checkout this PR and `npm link`
2. Check out https://github.com/LiveSafe/lvsf-email-templates/pull/7
3. In lvsf-email-templates run `npm link lvsf-gulp-tasks`
4. Run `npm tst` and see that lint, checkstyle, and mocha work as before
